### PR TITLE
Sort filesystem keys before iterating

### DIFF
--- a/btrfs-list
+++ b/btrfs-list
@@ -629,7 +629,7 @@ sub dothemagic {
 
 FREE_SPACE_ONLY:
 my $isFirstFS = 1;
-foreach my $fuuid (keys %filesystems) {
+foreach my $fuuid (sort keys %filesystems) {
     @ordered     = ();
     $maxdepth    = 0;
     $biggestpath = 0;


### PR DESCRIPTION
I know this seems petty, but each time I run the command with no arguments I get my two btrfs filesystems output in random order. Adding a sort on line 632 seems to output in a consistent order.

Thanks for the script!